### PR TITLE
refactor: update php-cs config for operator alignment and avoid trait blank lines

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -9,7 +9,10 @@ $rules = [
     'array_syntax' => ['syntax' => 'short'],
     'binary_operator_spaces' => [
         'default' => 'single_space',
-        'operators' => ['=>' => null],
+        'operators' => [
+            '=' => 'align',
+            '=>' => 'align',
+        ],
     ],
     'blank_line_after_namespace' => true,
     'blank_line_after_opening_tag' => true,

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -74,6 +74,7 @@ $rules = [
             'extra',
             'throw',
             'use',
+            'use_trait',
         ],
     ],
     'no_leading_import_slash' => true,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
This PR updates php-cs-config.php, in particular align operators like `=` and `=>`.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
